### PR TITLE
Use debug instead of console.log

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "url": "git+https://github.com/AlCalzone/node-coap-client.git"
   },
   "dependencies": {
-    "node-dtls-client": "git+https://github.com/AlCalzone/node-dtls-client.git"
+    "node-dtls-client": "git+https://github.com/AlCalzone/node-dtls-client.git",
+    "debug": "^3.0.0"
   },
   "scripts": {
     "test": "nyc mocha --recursive --compilers ts-node/register --require source-map-support/register --full-trace src/**/*.test.ts"

--- a/src/CoapClient.ts
+++ b/src/CoapClient.ts
@@ -1,4 +1,5 @@
 import * as crypto from "crypto";
+import * as debugPackage from "debug";
 import * as dgram from "dgram";
 import { dtls } from "node-dtls-client";
 import * as nodeUrl from "url";
@@ -8,6 +9,7 @@ import { Origin } from "./lib/Origin";
 import { SocketWrapper } from "./lib/SocketWrapper";
 import { Message, MessageCode, MessageCodes, MessageType } from "./Message";
 import { BinaryOption, NumericOption, Option, Options, StringOption } from "./Option";
+const debug = debugPackage("node-coap-client");
 
 export type RequestMethod = "get" | "post" | "put" | "delete";
 
@@ -222,7 +224,7 @@ export class CoapClient {
 			return;
 		}
 
-		console.log(`retransmitting message ${msgID.toString(16)}, try #${request.retransmit.counter + 1}`);
+		debug(`retransmitting message ${msgID.toString(16)}, try #${request.retransmit.counter + 1}`);
 
 		// resend the message
 		CoapClient.send(request.connection, request.originalMessage);
@@ -350,7 +352,7 @@ export class CoapClient {
 	private static onMessage(origin: string, message: Buffer, rinfo: dgram.RemoteInfo) {
 		// parse the CoAP message
 		const coapMsg = Message.parse(message);
-		console.log(`received message: ID=${coapMsg.messageId}${(coapMsg.token && coapMsg.token.length) ? (", token=" + coapMsg.token.toString("hex")) : ""}`);
+		debug(`received message: ID=${coapMsg.messageId}${(coapMsg.token && coapMsg.token.length) ? (", token=" + coapMsg.token.toString("hex")) : ""}`);
 
 		if (coapMsg.code.isEmpty()) {
 			// ACK or RST
@@ -359,13 +361,13 @@ export class CoapClient {
 			if (request != null) {
 				switch (coapMsg.type) {
 					case MessageType.ACK:
-						console.log(`received ACK for ${coapMsg.messageId.toString(16)}, stopping retransmission...`);
+						debug(`received ACK for ${coapMsg.messageId.toString(16)}, stopping retransmission...`);
 						// the other party has received the message, stop resending
 						CoapClient.stopRetransmission(request);
 						break;
 					case MessageType.RST:
 						// the other party doesn't know what to do with the request, forget it
-						console.log(`received RST for ${coapMsg.messageId.toString(16)}, forgetting the request...`);
+						debug(`received RST for ${coapMsg.messageId.toString(16)}, forgetting the request...`);
 						CoapClient.forgetRequest({ request });
 						break;
 				}
@@ -384,7 +386,7 @@ export class CoapClient {
 
 					// if the message is an acknowledgement, stop resending
 					if (coapMsg.type === MessageType.ACK) {
-						console.log(`received ACK for ${coapMsg.messageId.toString(16)}, stopping retransmission...`);
+						debug(`received ACK for ${coapMsg.messageId.toString(16)}, stopping retransmission...`);
 						CoapClient.stopRetransmission(request);
 					}
 
@@ -415,7 +417,7 @@ export class CoapClient {
 
 					// also acknowledge the packet if neccessary
 					if (coapMsg.type === MessageType.CON) {
-						console.log(`sending ACK for ${coapMsg.messageId.toString(16)}`);
+						debug(`sending ACK for ${coapMsg.messageId.toString(16)}`);
 						const ACK = CoapClient.createMessage(
 							MessageType.ACK,
 							MessageCodes.empty,
@@ -433,7 +435,7 @@ export class CoapClient {
 						const connection = CoapClient.connections[originString];
 
 						// and send the reset
-						console.log(`sending RST for ${coapMsg.messageId.toString(16)}`);
+						debug(`sending RST for ${coapMsg.messageId.toString(16)}`);
 						const RST = CoapClient.createMessage(
 							MessageType.RST,
 							MessageCodes.empty,
@@ -499,7 +501,7 @@ export class CoapClient {
 	) {
 		if (byToken) {
 			const tokenString = request.originalMessage.token.toString("hex");
-			console.log(`remembering request with token ${tokenString}`);
+			debug(`remembering request with token ${tokenString}`);
 			CoapClient.pendingRequestsByToken[tokenString] = request;
 		}
 		if (byMsgID) {
@@ -531,7 +533,7 @@ export class CoapClient {
 		// none found, return
 		if (request == null) return;
 
-		console.log(`forgetting request: token=${request.originalMessage.token.toString("hex")}; msgID=${request.originalMessage.messageId}`);
+		debug(`forgetting request: token=${request.originalMessage.token.toString("hex")}; msgID=${request.originalMessage.messageId}`);
 
 		// stop retransmission if neccessary
 		CoapClient.stopRetransmission(request);
@@ -646,12 +648,12 @@ export class CoapClient {
 				);
 				// try connecting
 				const onConnection = () => {
-					console.log("successfully created socket for origin " + origin.toString());
+					debug("successfully created socket for origin " + origin.toString());
 					sock.removeListener("error", onError);
 					ret.resolve(new SocketWrapper(sock));
 				};
 				const onError = (e: Error) => {
-					console.log("socket creation for origin " + origin.toString() + " failed: " + e);
+					debug("socket creation for origin " + origin.toString() + " failed: " + e);
 					sock.removeListener("connected", onConnection);
 					ret.reject(e.message);
 				};


### PR DESCRIPTION
Switches the package to using [debug](https://www.npmjs.com/package/debug) instead of writing directly to the console.

Debug output can be enabled by adding `DEBUG=node-coap-client` to the environment