### PR TITLE
Log errors in CoapClient.tryToConnect()

### DIFF
--- a/src/CoapClient.ts
+++ b/src/CoapClient.ts
@@ -1033,6 +1033,7 @@ export class CoapClient {
 			await CoapClient.getConnection(target);
 			return true;
 		} catch (e) {
+			debug(`tryToConnect(${target}) => failed with error: ${e}`);
 			return false;
 		}
 	}


### PR DESCRIPTION
I'm trying to use a library which uses this library (node-tradfri-client), where I've managed to find out that the attempts to establish a connection fail in this method. This commits adds a debug call to attempt to give the user some context as to why the attempt to establish a connection fails.