### PR TITLE
Add Uri-Query support

### DIFF
--- a/build/CoapClient.js
+++ b/build/CoapClient.js
@@ -250,6 +250,16 @@ class CoapClient {
             msgOptions.push(...pathParts.map(part => Option_1.Options.UriPath(part)));
             // [12] content format
             msgOptions.push(Option_1.Options.ContentFormat(ContentFormats_1.ContentFormats.application_json));
+            // [15] query
+            let query = url.query || "";
+            while (query.startsWith("?")) {
+                query = query.slice(1);
+            }
+            while (query.endsWith("&")) {
+                query = query.slice(0, -1);
+            }
+            const queryParts = query.split("&");
+            msgOptions.push(...queryParts.map(part => Option_1.Options.UriQuery(part)));
             // [23] Block2 (preferred response block size)
             if (options.preferredBlockSize != null) {
                 msgOptions.push(Option_1.Options.Block2(0, true, options.preferredBlockSize));
@@ -305,7 +315,7 @@ class CoapClient {
             if (typeof target === "string") {
                 target = Origin_1.Origin.parse(target);
             }
-            else if (!(target instanceof Origin_1.Origin)) {
+            else if (!(target instanceof Origin_1.Origin)) { // is a nodeUrl
                 target = Origin_1.Origin.fromUrl(target);
             }
             // retrieve or create the connection we're going to use
@@ -469,6 +479,16 @@ class CoapClient {
             msgOptions.push(...pathParts.map(part => Option_1.Options.UriPath(part)));
             // [12] content format
             msgOptions.push(Option_1.Options.ContentFormat(ContentFormats_1.ContentFormats.application_json));
+            // [15] query
+            let query = url.query || "";
+            while (query.startsWith("?")) {
+                query = query.slice(1);
+            }
+            while (query.endsWith("&")) {
+                query = query.slice(0, -1);
+            }
+            const queryParts = query.split("&");
+            msgOptions.push(...queryParts.map(part => Option_1.Options.UriQuery(part)));
             // In contrast to requests, we don't work with a deferred promise when observing
             // Instead, we invoke a callback for *every* response.
             // create the message we're going to send
@@ -529,7 +549,7 @@ class CoapClient {
                         break;
                     case Message_1.MessageType.RST:
                         if (request.originalMessage.type === Message_1.MessageType.CON &&
-                            request.originalMessage.code === Message_1.MessageCodes.empty) {
+                            request.originalMessage.code === Message_1.MessageCodes.empty) { // this message was a ping (empty CON, answered by RST)
                             // resolve the promise
                             debug(`received response to ping with ID 0x${coapMsg.messageId.toString(16)}`);
                             request.promise.resolve();
@@ -618,7 +638,7 @@ class CoapClient {
                         CoapClient.send(request.connection, ACK, "immediate");
                     }
                 }
-                else {
+                else { // request == null
                     // no request found for this token, send RST so the server stops sending
                     // try to find the connection that belongs to this origin
                     const originString = origin.toString();
@@ -839,7 +859,7 @@ class CoapClient {
             if (typeof target === "string") {
                 target = Origin_1.Origin.parse(target);
             }
-            else if (!(target instanceof Origin_1.Origin)) {
+            else if (!(target instanceof Origin_1.Origin)) { // is a nodeUrl
                 target = Origin_1.Origin.fromUrl(target);
             }
             // retrieve or create the connection we're going to use

--- a/build/Option.d.ts
+++ b/build/Option.d.ts
@@ -102,6 +102,7 @@ export declare const Options: Readonly<{
     UriHost: (hostname: string) => Option;
     UriPort: (port: number) => Option;
     UriPath: (pathname: string) => Option;
+    UriQuery: (query: string) => Option;
     LocationPath: (pathname: string) => Option;
     ContentFormat: (format: ContentFormats) => Option;
     Observe: (observe: boolean) => Option;

--- a/build/Option.js
+++ b/build/Option.js
@@ -71,6 +71,7 @@ class Option {
             case 15:
                 throw new Error("invalid option format");
             default:
+            // all good
         }
         // handle special cases for the length
         switch (length) {
@@ -85,6 +86,7 @@ class Option {
             case 15:
                 throw new Error("invalid option format");
             default:
+            // all good
         }
         const rawValue = Buffer.from(buf.slice(dataStart, dataStart + length));
         const code = prevCode + delta;
@@ -111,7 +113,7 @@ class Option {
         const ret = Buffer.allocUnsafe(totalLength);
         let dataStart = 1;
         // check if we need to split the delta in 2 parts
-        if (delta < 13) {
+        if (delta < 13) { /* all good */
         }
         else if (delta < 269) {
             extraDelta = delta - 13;
@@ -126,7 +128,7 @@ class Option {
             dataStart += 2;
         }
         // check if we need to split the length in 2 parts
-        if (length < 13) {
+        if (length < 13) { /* all good */
         }
         else if (length < 269) {
             extraLength = length - 13;
@@ -350,6 +352,7 @@ exports.Options = Object.freeze({
     UriHost: (hostname) => optionConstructors["Uri-Host"](Buffer.from(hostname)),
     UriPort: (port) => optionConstructors["Uri-Port"](numberToBuffer(port)),
     UriPath: (pathname) => optionConstructors["Uri-Path"](Buffer.from(pathname)),
+    UriQuery: (query) => optionConstructors["Uri-Query"](Buffer.from(query)),
     LocationPath: (pathname) => optionConstructors["Location-Path"](Buffer.from(pathname)),
     ContentFormat: (format) => optionConstructors["Content-Format"](numberToBuffer(format)),
     Observe: (observe) => optionConstructors["Observe"](Buffer.from([observe ? 0 : 1])),

--- a/src/CoapClient.ts
+++ b/src/CoapClient.ts
@@ -345,6 +345,14 @@ export class CoapClient {
 		);
 		// [12] content format
 		msgOptions.push(Options.ContentFormat(ContentFormats.application_json));
+		// [15] query
+		let query: string = url.query || "";
+		while (query.startsWith("?")) { query = query.slice(1); }
+		while (query.endsWith("&")) { query = query.slice(0, -1); }
+		const queryParts = query.split("&");
+		msgOptions.push(
+			...queryParts.map(part => Options.UriQuery(part)),
+		);
 		// [23] Block2 (preferred response block size)
 		if (options.preferredBlockSize != null) {
 			msgOptions.push(Options.Block2(0, true, options.preferredBlockSize));
@@ -597,6 +605,14 @@ export class CoapClient {
 		);
 		// [12] content format
 		msgOptions.push(Options.ContentFormat(ContentFormats.application_json));
+		// [15] query
+		let query: string = url.query || "";
+		while (query.startsWith("?")) { query = query.slice(1); }
+		while (query.endsWith("&")) { query = query.slice(0, -1); }
+		const queryParts = query.split("&");
+		msgOptions.push(
+			...queryParts.map(part => Options.UriQuery(part)),
+		);
 
 		// In contrast to requests, we don't work with a deferred promise when observing
 		// Instead, we invoke a callback for *every* response.

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -450,6 +450,7 @@ export const Options = Object.freeze({
 	UriHost: (hostname: string) => optionConstructors["Uri-Host"](Buffer.from(hostname)),
 	UriPort: (port: number) => optionConstructors["Uri-Port"](numberToBuffer(port)),
 	UriPath: (pathname: string) => optionConstructors["Uri-Path"](Buffer.from(pathname)),
+	UriQuery: (query: string) => optionConstructors["Uri-Query"](Buffer.from(query)),
 
 	LocationPath: (pathname: string) => optionConstructors["Location-Path"](Buffer.from(pathname)),
 


### PR DESCRIPTION
So far, the query part of a given URI has been ignored, as no Uri-Query options are added to requests.

This PR lets the CoapClient also add Uri-Query options to the request.