### PR TITLE
Lowercase the hostname in normalizeHostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ To only reset connections and requests for a specific hostname, pass the hostnam
     ### __WORK IN PROGRESS__
 -->
 
+### __WORK IN PROGRESS__
+* (AlCalzone) All hostnames are now always normalized to lowercase
+
 ### 1.0.3 (2020-02-29)
 * (AlCalzone) An unknown PSK is now treated like an invalid password
 

--- a/src/CoapClient.ts
+++ b/src/CoapClient.ts
@@ -188,7 +188,7 @@ function normalizeHostname(hostname: string): string {
 	if (!hostname.startsWith("coap://") && !hostname.startsWith("coaps://")) {
 		hostname = `coaps://${getURLSafeHostname(hostname)}`;
 	}
-	return new URL(hostname).hostname;
+	return new URL(hostname).hostname.toLowerCase();
 }
 
 /**


### PR DESCRIPTION
so getSocket works with the same hostname casing as setSecurityParams