### PR TITLE
fix: parse IPv6 addresses from url

### DIFF
--- a/build/CoapClient.js
+++ b/build/CoapClient.js
@@ -9,7 +9,6 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.CoapClient = void 0;
 const crypto = require("crypto");
 const dgram = require("dgram");
 const net_1 = require("net");

--- a/build/ContentFormats.js
+++ b/build/ContentFormats.js
@@ -1,6 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.ContentFormats = void 0;
 var ContentFormats;
 (function (ContentFormats) {
     ContentFormats[ContentFormats["text_plain"] = 0] = "text_plain";

--- a/build/Message.js
+++ b/build/Message.js
@@ -1,6 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.Message = exports.MessageCodes = exports.MessageCode = exports.MessageType = void 0;
 const Option_1 = require("./Option");
 var MessageType;
 (function (MessageType) {

--- a/build/Option.js
+++ b/build/Option.js
@@ -1,6 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.findOptions = exports.findOption = exports.Options = exports.StringOption = exports.BinaryOption = exports.BlockOption = exports.NumericOption = exports.Option = void 0;
 function numberToBuffer(value) {
     const ret = [];
     // According to https://tools.ietf.org/html/rfc7252#section-3.2

--- a/build/lib/DeferredPromise.js
+++ b/build/lib/DeferredPromise.js
@@ -1,6 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.createDeferredPromise = void 0;
 function normalizeReason(reason) {
     if (typeof reason === "string")
         return new Error(reason);

--- a/build/lib/Hostname.d.ts
+++ b/build/lib/Hostname.d.ts
@@ -1,4 +1,5 @@
 /** Converts the given hostname to be used in an URL. Wraps IPv6 addresses in square brackets */
 export declare function getURLSafeHostname(hostname: string): string;
+export declare function getSocketAddressFromURLSafeHostnameWithoutLookup(hostname: string): string;
 /** Takes an URL-safe hostname and converts it to an address to be used in UDP sockets */
 export declare function getSocketAddressFromURLSafeHostname(hostname: string): Promise<string>;

--- a/build/lib/Hostname.js
+++ b/build/lib/Hostname.js
@@ -9,7 +9,6 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getSocketAddressFromURLSafeHostname = exports.getURLSafeHostname = void 0;
 const dns = require("dns");
 const net_1 = require("net");
 /** Converts the given hostname to be used in an URL. Wraps IPv6 addresses in square brackets */
@@ -19,6 +18,15 @@ function getURLSafeHostname(hostname) {
     return hostname;
 }
 exports.getURLSafeHostname = getURLSafeHostname;
+function getSocketAddressFromURLSafeHostnameWithoutLookup(hostname) {
+    // IPv4 addresses are fine
+    if (net_1.isIPv4(hostname))
+        return hostname;
+    // IPv6 addresses are wrapped in [], which need to be removed
+    if (/^\[.+\]$/.test(hostname))
+        return hostname.slice(1, -1);
+}
+exports.getSocketAddressFromURLSafeHostnameWithoutLookup = getSocketAddressFromURLSafeHostnameWithoutLookup;
 /** Takes an URL-safe hostname and converts it to an address to be used in UDP sockets */
 function getSocketAddressFromURLSafeHostname(hostname) {
     return __awaiter(this, void 0, void 0, function* () {

--- a/build/lib/LogMessage.js
+++ b/build/lib/LogMessage.js
@@ -1,6 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.logMessage = void 0;
 // initialize debugging
 const debugPackage = require("debug");
 const debug = debugPackage("node-coap-client:message");

--- a/build/lib/Origin.js
+++ b/build/lib/Origin.js
@@ -1,6 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.Origin = void 0;
 const Hostname_1 = require("./Hostname");
 const url_1 = require("url");
 /**

--- a/build/lib/SocketWrapper.js
+++ b/build/lib/SocketWrapper.js
@@ -1,8 +1,8 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.SocketWrapper = void 0;
 const events_1 = require("events");
 const node_dtls_client_1 = require("node-dtls-client");
+const Hostname_1 = require("./Hostname");
 class SocketWrapper extends events_1.EventEmitter {
     constructor(socket) {
         super();
@@ -26,7 +26,7 @@ class SocketWrapper extends events_1.EventEmitter {
             this.socket.send(msg);
         }
         else {
-            this.socket.send(msg, origin.port, origin.hostname);
+            this.socket.send(msg, origin.port, Hostname_1.getSocketAddressFromURLSafeHostnameWithoutLookup(origin.hostname));
         }
     }
     close() {

--- a/build/lib/strings.js
+++ b/build/lib/strings.js
@@ -1,6 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.padStart = void 0;
 /**
  * Pads a string to the given length by repeatedly prepending the filler at the beginning of the string.
  * @param str The string to pad

--- a/src/lib/Hostname.ts
+++ b/src/lib/Hostname.ts
@@ -7,6 +7,13 @@ export function getURLSafeHostname(hostname: string): string {
 	return hostname;
 }
 
+export function getSocketAddressFromURLSafeHostnameWithoutLookup(hostname: string): string {
+	// IPv4 addresses are fine
+	if (isIPv4(hostname)) return hostname;
+	// IPv6 addresses are wrapped in [], which need to be removed
+	if (/^\[.+\]$/.test(hostname)) return hostname.slice(1, -1);
+}
+
 /** Takes an URL-safe hostname and converts it to an address to be used in UDP sockets */
 export async function getSocketAddressFromURLSafeHostname(hostname: string): Promise<string> {
 	// IPv4 addresses are fine

--- a/src/lib/SocketWrapper.ts
+++ b/src/lib/SocketWrapper.ts
@@ -2,6 +2,7 @@ import * as dgram from "dgram";
 import { EventEmitter } from "events";
 import { dtls } from "node-dtls-client";
 import { Origin } from "./Origin";
+import { getSocketAddressFromURLSafeHostnameWithoutLookup } from "./Hostname";
 
 export class SocketWrapper extends EventEmitter {
 
@@ -29,7 +30,7 @@ export class SocketWrapper extends EventEmitter {
 		if (this.isDtls) {
 			(this.socket as dtls.Socket).send(msg);
 		} else {
-			(this.socket as dgram.Socket).send(msg, origin.port, origin.hostname);
+			(this.socket as dgram.Socket).send(msg, origin.port, getSocketAddressFromURLSafeHostnameWithoutLookup(origin.hostname));
 		}
 	}
 


### PR DESCRIPTION
When i tried to send an request to an IPv6 address, the following error occurred:

```
events.js:352
      throw er; // Unhandled 'error' event
      ^

Error: getaddrinfo ENOTFOUND [::1]
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:69:26)
Emitted 'error' event on SocketWrapper instance at:
    at Socket.<anonymous> (/home/cornelius/Nextcloud/Uni/SoSe21/Bachelorarbeit/node-coap-client-master/build/lib/SocketWrapper.js:16:18)
    at Socket.emit (events.js:375:28)
    at dgram.js:683:33
    at processTicksAndRejections (internal/process/task_queues.js:77:11) {
  errno: -3008,
  code: 'ENOTFOUND',
  syscall: 'getaddrinfo',
  hostname: '[::1]'
}
```

I figured out, that the problem had something to do with how the URL get parsed in `Origin.fromUrl`. I think this PR should solve the problem.
